### PR TITLE
feat(phase-8): Step 8 — Linux + Docker CI workflows

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,14 +13,12 @@ on:
       - .dockerignore
       - pyproject.toml
       - uv.lock
-      - .github/workflows/docker-build.yml
   pull_request:
     paths:
       - Dockerfile
       - .dockerignore
       - pyproject.toml
       - uv.lock
-      - .github/workflows/docker-build.yml
 
 concurrency:
   group: docker-build-${{ github.ref }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,52 @@
+name: docker-build
+
+# The Phase 8 Dockerfile is added in Step 9. This workflow's `paths`
+# filter means it does NOT fire on PRs that don't touch the listed
+# files — so it stays inert until Step 9 lands the Dockerfile + the
+# first PR that exercises a `docker build`. End-to-end validation
+# (intentional Dockerfile typo caught) belongs to Step 9.
+on:
+  push:
+    branches: [master]
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/docker-build.yml
+  pull_request:
+    paths:
+      - Dockerfile
+      - .dockerignore
+      - pyproject.toml
+      - uv.lock
+      - .github/workflows/docker-build.yml
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: docker build (no push)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build-only, no registry push. Image stays on the runner and is
+      # discarded when the job ends. Catches Dockerfile regressions
+      # (apt typos, COPY-before-uv-sync ordering, missing build-args)
+      # before they hit a deployment host.
+      - name: Build worker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          tags: alpha4gate-worker:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -1,0 +1,58 @@
+name: linux-tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# Cancel superseded runs on the same ref so PRs don't pile up.
+concurrency:
+  group: linux-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ruff + mypy + pytest (ubuntu-22.04 / py3.12)
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.11.7"
+
+      # Phase 8 spec: cache uv downloads keyed on uv.lock at ~/.cache/uv.
+      # Hits whenever uv.lock is unchanged, regardless of branch.
+      - name: Cache uv downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-py3.12-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-py3.12-
+
+      # `--extra dev` is required: pytest/ruff/mypy/httpx/pre-commit live
+      # under [project.optional-dependencies] dev. A bare `uv sync`
+      # produces a runtime-only venv (see wiki/linux-dev-environment.md).
+      - name: Sync dev environment
+        run: uv sync --frozen --extra dev
+
+      - name: Lint (ruff)
+        run: uv run ruff check .
+
+      - name: Type-check (mypy --strict)
+        run: uv run mypy src bots --strict
+
+      # No SC2 install on the GitHub-hosted runner; deselect via marker
+      # rather than file-ignore so the gate survives test relocations.
+      # `pytest -m sc2` integration tests run only on a real SC2 host.
+      - name: Unit tests (no sc2 marker)
+        run: uv run pytest -m "not sc2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Alpha4Gate
 
-![Python](https://img.shields.io/badge/python-3.12-blue) ![pytest](https://img.shields.io/badge/pytest-1313%20passing-brightgreen) ![vitest](https://img.shields.io/badge/vitest-143%20passing-brightgreen) ![Self-improvement](https://img.shields.io/badge/self--improvement-closed--loop-purple)
+![Python](https://img.shields.io/badge/python-3.12-blue) [![linux-tests](https://github.com/aberson/Alpha4Gate/actions/workflows/linux-tests.yml/badge.svg?branch=master)](https://github.com/aberson/Alpha4Gate/actions/workflows/linux-tests.yml) ![pytest](https://img.shields.io/badge/pytest-1329%20passing-brightgreen) ![vitest](https://img.shields.io/badge/vitest-143%20passing-brightgreen) ![Self-improvement](https://img.shields.io/badge/self--improvement-closed--loop-purple)
 
 An AI agent that teaches itself to get better at a task with — zero human input.
 

--- a/src/orchestrator/paths.py
+++ b/src/orchestrator/paths.py
@@ -7,10 +7,15 @@ fallback table:
 
 * ``$SC2PATH`` — honored first, regardless of platform. Always wins.
 * Windows (``sys.platform == "win32"``) → ``C:\\Program Files (x86)\\StarCraft II``.
-* WSL2 (Linux kernel with ``microsoft`` in ``/proc/version``) →
-  ``/mnt/c/Program Files (x86)/StarCraft II`` (the Windows install
-  reachable through DrvFS — convenient for ad-hoc WSL invocations
-  without a Linux SC2 install).
+* WSL2 (Linux kernel with ``microsoft`` in ``/proc/version``):
+    * If ``SC2_WSL_DETECT=0`` (the Phase 8 pure-Linux opt-in) →
+      ``~/StarCraftII`` (matches the WSL Ubuntu-22.04 install convention;
+      necessary because burnysc2 in pure-Linux mode launches the Linux
+      ``SC2_x64`` binary, which only exists at the native-Linux layout).
+    * Otherwise → ``/mnt/c/Program Files (x86)/StarCraft II`` (the Windows
+      install reachable through DrvFS — convenient for ad-hoc WSL
+      invocations without a Linux SC2 install, paired with burnysc2's
+      auto-detected WSL2 mode that runs ``SC2_x64.exe`` via PowerShell).
 * Linux native → ``~/StarCraftII`` (Blizzard's documented Linux layout;
   matches the Phase 8 WSL Ubuntu-22.04 install convention).
 * Anything else (macOS, BSDs) → :class:`RuntimeError`.
@@ -63,6 +68,8 @@ def resolve_sc2_path() -> Path:
         return _WINDOWS_DEFAULT
     if sys.platform == "linux":
         if _is_wsl():
+            if os.environ.get("SC2_WSL_DETECT") == "0":
+                return Path.home() / "StarCraftII"
             return _WSL_DEFAULT
         return Path.home() / "StarCraftII"
 

--- a/src/orchestrator/paths.py
+++ b/src/orchestrator/paths.py
@@ -31,9 +31,6 @@ import os
 import sys
 from pathlib import Path
 
-if sys.platform != "win32":
-    raise RuntimeError("intentional CI validation break — DO NOT MERGE")
-
 __all__ = ["resolve_sc2_path"]
 
 

--- a/src/orchestrator/paths.py
+++ b/src/orchestrator/paths.py
@@ -31,6 +31,9 @@ import os
 import sys
 from pathlib import Path
 
+if sys.platform != "win32":
+    raise RuntimeError("intentional CI validation break — DO NOT MERGE")
+
 __all__ = ["resolve_sc2_path"]
 
 

--- a/tests/test_sc2path_fallback.py
+++ b/tests/test_sc2path_fallback.py
@@ -50,6 +50,35 @@ class TestLinuxNative:
 class TestWSL:
     def test_wsl_uses_mnt_c_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("SC2PATH", raising=False)
+        monkeypatch.delenv("SC2_WSL_DETECT", raising=False)
+        monkeypatch.setattr(paths.sys, "platform", "linux")
+        monkeypatch.setattr(paths, "_is_wsl", lambda: True)
+        assert paths.resolve_sc2_path() == Path(
+            "/mnt/c/Program Files (x86)/StarCraft II"
+        )
+
+    def test_wsl_with_sc2_wsl_detect_zero_uses_home_starcraftii(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        # Phase 8 pure-Linux opt-in: when SC2_WSL_DETECT=0, burnysc2 stays
+        # in Linux mode and tries to launch the binary at
+        # <SC2PATH>/Versions/Base*/SC2_x64 (no .exe). The /mnt/c install
+        # only has SC2_x64.exe, so the resolver must point at the
+        # native-Linux layout instead. Caught by Phase 8 Step 7 smoke gate.
+        monkeypatch.delenv("SC2PATH", raising=False)
+        monkeypatch.setenv("SC2_WSL_DETECT", "0")
+        monkeypatch.setattr(paths.sys, "platform", "linux")
+        monkeypatch.setattr(paths, "_is_wsl", lambda: True)
+        monkeypatch.setattr(paths.Path, "home", classmethod(lambda cls: tmp_path))
+        assert paths.resolve_sc2_path() == tmp_path / "StarCraftII"
+
+    def test_wsl_with_sc2_wsl_detect_nonzero_keeps_mnt_c(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Only the literal value "0" triggers the pure-Linux branch; any
+        # other value (including "1") leaves the WSL2-mode default in place.
+        monkeypatch.delenv("SC2PATH", raising=False)
+        monkeypatch.setenv("SC2_WSL_DETECT", "1")
         monkeypatch.setattr(paths.sys, "platform", "linux")
         monkeypatch.setattr(paths, "_is_wsl", lambda: True)
         assert paths.resolve_sc2_path() == Path(


### PR DESCRIPTION
## Summary

- **Pre-Step-8 fix** (`6233516`): `resolve_sc2_path()` now respects `SC2_WSL_DETECT=0` on WSL — returns `~/StarCraftII` instead of the unlaunchable `/mnt/c/...`. Caught by Phase 8 Step 7 smoke gate Path A. Two new tests; production happy-path unchanged (branch 1 still wins when `SC2PATH` is set).
- **Step 8 workflows** (`e9b35c7`, `7ee11fa`): `linux-tests.yml` runs ruff + mypy --strict + pytest -m "not sc2" on ubuntu-22.04 / Python 3.12 / uv 0.11.7, with `actions/cache` keyed on `uv.lock` at `~/.cache/uv`. `docker-build.yml` is staged with a `paths:` filter limited to actual build inputs (Dockerfile/.dockerignore/pyproject.toml/uv.lock) — inert until Step 9 lands the Dockerfile.
- **README**: live `linux-tests` status badge + pytest count refreshed to 1329.

## Spec deviation (intentional)

The plan-doc Step 8 spec calls for *"intentional Dockerfile typo caught by docker-build"* as part of the validation. That isn't possible in Step 8 because the Phase 8 Dockerfile lives in Step 9. End-to-end docker-build validation is deferred to Step 9. The workflow file ships ready-to-fire on the Step 9 PR.

## Test plan

- [x] Local: 1329 pytest pass (+2 new resolver tests), mypy strict clean (178 files), ruff clean — Windows host
- [x] CI: `linux-tests` workflow green on this PR — run [24975860563](https://github.com/aberson/Alpha4Gate/actions/runs/24975860563) (1m53s)
- [x] CI: intentional cross-platform break caught — added `if sys.platform != "win32": raise RuntimeError(...)` at module top of `src/orchestrator/paths.py` (`5797de7`); run [24978307538](https://github.com/aberson/Alpha4Gate/actions/runs/24978307538) failed at pytest collection on the Linux runner (ruff and mypy both passed; the failure is specifically pytest catching the runtime regression). Reverted in `982b939`; run [24978363611](https://github.com/aberson/Alpha4Gate/actions/runs/24978363611) returned to green. The break never affected Windows host because `sys.platform == "win32"` there — proving the workflow catches Linux-only regressions a Windows-only dev gate would miss.
- [x] CI: `docker-build` workflow stays inert on this PR — no listed input file (Dockerfile/.dockerignore/pyproject.toml/uv.lock) changed in the cumulative PR diff, so the workflow correctly does not trigger on the current head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)